### PR TITLE
Allow the consistent use of answer letters in file `questions.md`

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -16,4 +16,4 @@ jobs:
     with:
       skip-prerelease: true
       # A Git ref in the repository istqb_product_base, which should be used for the LaTeX+Markdown template
-      base-version: feat/answer-letters-in-questions-dot-md
+      base-version: main

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -16,4 +16,4 @@ jobs:
     with:
       skip-prerelease: true
       # A Git ref in the repository istqb_product_base, which should be used for the LaTeX+Markdown template
-      base-version: main
+      base-version: feat/answer-letters-in-questions-dot-md

--- a/sample-exam/questions.md
+++ b/sample-exam/questions.md
@@ -8,10 +8,10 @@ correct: c
 Which of the following statements describe a valid test objective?
 
 ## answers
-1. To prove that there are no unfixed defects in the system under test
-2. To prove that there will be no failures after the implementation of the system into production
-3. To reduce the risk level of the test object and to build confidence in the quality level
-4. To verify that there are no untested combinations of inputs
+a. To prove that there are no unfixed defects in the system under test
+b. To prove that there will be no failures after the implementation of the system into production
+c. To reduce the risk level of the test object and to build confidence in the quality level
+d. To verify that there are no untested combinations of inputs
 
 ## justification
 a. Is not correct. It is impossible to prove that there are no defects anymore in the system under test.
@@ -37,10 +37,10 @@ iv. New regulatory requirements forcing
 v. The number of certified testers in the organization
 
 ## answers
-1. i, ii have significant influence; iii, iv, v have not
-2. i, iii, iv have significant influence; ii, v have not
-3. ii, iv, v have significant influence; i, iii have not
-4. iii, v have significant influence; i, ii, iv have not
+a. i, ii have significant influence; iii, iv, v have not
+b. i, iii, iv have significant influence; ii, v have not
+c. ii, iv, v have significant influence; i, iii have not
+d. iii, v have significant influence; i, ii, iv have not
 
 ## justification
 i.   Is true. The SDLC has an influence on the test process
@@ -100,10 +100,10 @@ D. Test completion
 Which of the following BEST matches the activities with the tasks?
 
 ## answers
-1. A-2, B-3, C-4, D-1
-2. A-2, B-1, C-3, D-4
-3. A-3, B-2, C-4, D-1
-4. A-3, B-2, C-1, D-4
+a) A-2, B-3, C-4, D-1
+b) A-2, B-1, C-3, D-4
+c) A-3, B-2, C-4, D-1
+d) A-3, B-2, C-1, D-4
 
 ## justification
 The correct pairing of test activities and tasks is:

--- a/sample-exam/questions.md
+++ b/sample-exam/questions.md
@@ -59,7 +59,7 @@ Hence b is correct.
 lo: 1.4.5
 k-level: K2
 points: 1
-correct: ['a', 'e']
+correct: [1, '5']
 
 ## question
 Which TWO of the following tasks belong MAINLY to a testing role?

--- a/sample-exam/questions.md
+++ b/sample-exam/questions.md
@@ -14,12 +14,12 @@ Which of the following statements describe a valid test objective?
 4. To verify that there are no untested combinations of inputs
 
 ## justification
-a) Is not correct. It is impossible to prove that there are no defects anymore in the system under test.
+a. Is not correct. It is impossible to prove that there are no defects anymore in the system under test.
    See testing principle 1
-b) Is not correct. See testing principle 7
-c) Is correct. Testing finds defects and failures which reduces the level of risk and at the same time
+b. Is not correct. See testing principle 7
+c. Is correct. Testing finds defects and failures which reduces the level of risk and at the same time
    gives more confidence in the quality level of the test object
-d) Is not correct. It is impossible to test all combinations of inputs (see testing principle 2)
+d. Is not correct. It is impossible to test all combinations of inputs (see testing principle 2)
 
 # metadata
 lo: 1.4.2
@@ -115,7 +115,7 @@ D. Test completion – (1) Entering change requests for open defect reports
 
 Thus:
 
-a) Is correct
-b) Is not correct
-c) Is not correct
-d) Is not correct
+a. Is correct
+b. Is not correct
+c. Is not correct
+d. Is not correct


### PR DESCRIPTION
This PR updates `questions.md` to showcase the changes from PR https://github.com/istqborg/istqb_product_base/pull/116:

- The preferred input format is `a.` or `a)` sections `## answers` and `## justification` and a–e in the `correct:` field from section `# metadata`:

  https://github.com/istqborg/istqb_product_template/blob/64d348eeb12d7f9e4ae82c5983e97f559d797ff8/sample-exam/questions.md?plain=1#L1-L22

  - PDF output:
      - Sample Exam Questions:
        ![image](https://github.com/user-attachments/assets/341b4993-2d49-4b9d-8952-6ddfe22a797b)
      - Sample Exam Answers:
        ![image](https://github.com/user-attachments/assets/bc0a5353-6743-46eb-8d0b-fa0376b49049)
  - DOCX output:    
    ![image](https://github.com/user-attachments/assets/b9172ce1-5fe8-4aa3-9231-71f9d106af92)

- For backwards compatibility with the previous format, `1.` can be used in section `## answers` and 1–5 can be used in the `correct:` field from section `# metadata`:

  https://github.com/istqborg/istqb_product_template/blob/64d348eeb12d7f9e4ae82c5983e97f559d797ff8/sample-exam/questions.md?plain=1#L58-L79

  - PDF output:
      - Sample Exam Questions:        
        ![image](https://github.com/user-attachments/assets/93e62a6d-783e-443e-b543-2058ea0e6dd5)
      - Sample Exam Answers:
        ![image](https://github.com/user-attachments/assets/f4500bcf-214d-4e82-8f95-fb25ec83b205)
  - DOCX output:
    ![image](https://github.com/user-attachments/assets/d39f3da1-2729-4a1e-9893-e117f4d7f09a)

This PR should be merged after PR https://github.com/istqborg/istqb_product_base/pull/116 has been merged and after commit 64d348e from this PR has been reverted.