### PR TITLE
Hotfix/fancy lists with trailing spaces

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -16,4 +16,4 @@ jobs:
     with:
       skip-prerelease: true
       # A Git ref in the repository istqb_product_base, which should be used for the LaTeX+Markdown template
-      base-version: hotfix/fancy-lists-with-trailing-spaces
+      base-version: main

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -16,4 +16,4 @@ jobs:
     with:
       skip-prerelease: true
       # A Git ref in the repository istqb_product_base, which should be used for the LaTeX+Markdown template
-      base-version: main
+      base-version: hotfix/fancy-lists-with-trailing-spaces

--- a/sample-exam/questions.md
+++ b/sample-exam/questions.md
@@ -8,18 +8,18 @@ correct: c
 Which of the following statements describe a valid test objective?
 
 ## answers
-a. To prove that there are no unfixed defects in the system under test
-b. To prove that there will be no failures after the implementation of the system into production
-c. To reduce the risk level of the test object and to build confidence in the quality level
-d. To verify that there are no untested combinations of inputs
+a. To prove that there are no unfixed defects in the system under test  
+b. To prove that there will be no failures after the implementation of the system into production  
+c. To reduce the risk level of the test object and to build confidence in the quality level  
+d. To verify that there are no untested combinations of inputs  
 
 ## justification
 a. Is not correct. It is impossible to prove that there are no defects anymore in the system under test.
-   See testing principle 1
-b. Is not correct. See testing principle 7
+   See testing principle 1  
+b. Is not correct. See testing principle 7  
 c. Is correct. Testing finds defects and failures which reduces the level of risk and at the same time
-   gives more confidence in the quality level of the test object
-d. Is not correct. It is impossible to test all combinations of inputs (see testing principle 2)
+   gives more confidence in the quality level of the test object  
+d. Is not correct. It is impossible to test all combinations of inputs (see testing principle 2)  
 
 # metadata
 lo: 1.4.2
@@ -30,28 +30,28 @@ correct: b
 ## question
 Which of the following factors (i-v) have SIGNIFICANT influence on the test process?
 
-i. The SDLC
-ii. The number of defects detected in previous projects
-iii. The identified product risks
-iv. New regulatory requirements forcing
-v. The number of certified testers in the organization
+i. The SDLC  
+ii. The number of defects detected in previous projects  
+iii. The identified product risks  
+iv. New regulatory requirements forcing  
+v. The number of certified testers in the organization  
 
 ## answers
-a. i, ii have significant influence; iii, iv, v have not
-b. i, iii, iv have significant influence; ii, v have not
-c. ii, iv, v have significant influence; i, iii have not
-d. iii, v have significant influence; i, ii, iv have not
+a. i, ii have significant influence; iii, iv, v have not  
+b. i, iii, iv have significant influence; ii, v have not  
+c. ii, iv, v have significant influence; i, iii have not  
+d. iii, v have significant influence; i, ii, iv have not  
 
 ## justification
-i.   Is true. The SDLC has an influence on the test process
+i.   Is true. The SDLC has an influence on the test process  
 ii.  Is false. The number of defects detected in previous projects may have
-     some influence, but this is not as significant as i, iii and iv
+     some influence, but this is not as significant as i, iii and iv  
 iii. Is true. The identified product risks are one of the most important
-     factors influencing the test process
+     factors influencing the test process  
 iv.  Is true. Regulatory requirements are important factors influencing the
-     test process
+     test process  
 v.   Is false. The test environment should be a copy of the production
-     environment but has no significant influence on the test process
+     environment but has no significant influence on the test process  
 
 Hence b is correct.
 
@@ -72,11 +72,11 @@ Which TWO of the following tasks belong MAINLY to a testing role?
 5. Report on achieved coverage
 
 ## justification
-a) Is correct. This is done by the testers
-b) Is not correct. The product backlog is built and maintained by the product owner
-c) Is not correct. This is done by the development team
-d) Is not correct. This is a managerial role
-e) Is correct. This is done by the testers
+a) Is correct. This is done by the testers  
+b) Is not correct. The product backlog is built and maintained by the product owner  
+c) Is not correct. This is done by the development team  
+d) Is not correct. This is a managerial role  
+e) Is correct. This is done by the testers  
 
 # metadata
 lo: 1.4.2
@@ -87,10 +87,10 @@ correct: a
 ## question
 Given the following test activities and tasks:
 
-A. Test design
-B. Test implementation
-C. Test execution
-D. Test completion
+A) Test design  
+B) Test implementation  
+C) Test execution  
+D) Test completion  
 
 1. Entering change requests for open defect reports
 2. Identifying test data to support the test cases
@@ -100,22 +100,22 @@ D. Test completion
 Which of the following BEST matches the activities with the tasks?
 
 ## answers
-a) A-2, B-3, C-4, D-1
-b) A-2, B-1, C-3, D-4
-c) A-3, B-2, C-4, D-1
-d) A-3, B-2, C-1, D-4
+a) A-2, B-3, C-4, D-1  
+b) A-2, B-1, C-3, D-4  
+c) A-3, B-2, C-4, D-1  
+d) A-3, B-2, C-1, D-4  
 
 ## justification
 The correct pairing of test activities and tasks is:
 
-A. Test design – (2) Identifying test data to support the test cases
-B. Test implementation – (3) Prioritizing test procedures and creating test data
-C. Test execution – (4) Analyzing discrepancies to determine their cause
-D. Test completion – (1) Entering change requests for open defect reports
+A) Test design – (2) Identifying test data to support the test cases  
+B) Test implementation – (3) Prioritizing test procedures and creating test data  
+C) Test execution – (4) Analyzing discrepancies to determine their cause  
+D) Test completion – (1) Entering change requests for open defect reports  
 
 Thus:
 
-a. Is correct
-b. Is not correct
-c. Is not correct
-d. Is not correct
+a. Is correct  
+b. Is not correct  
+c. Is not correct  
+d. Is not correct  


### PR DESCRIPTION
This PR hotfixes https://github.com/Witiko/markdown/issues/508, which made it previously impossible to have trailing spaces in [fancy list][1] items.

 [1]: https://witiko.github.io/markdown/#option-fancylists