### PR TITLE
Include additional questions in the Sample Exam documents

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -16,4 +16,4 @@ jobs:
     with:
       skip-prerelease: true
       # A Git ref in the repository istqb_product_base, which should be used for the LaTeX+Markdown template
-      base-version: main
+      base-version: feat/additional-questions

--- a/sample-exam-answers.tex
+++ b/sample-exam-answers.tex
@@ -2,7 +2,7 @@
 \usepackage{markdown}
 \markdownSetup{
   import = {
-    istqb/sample-exam/answers = {metadata, answer-key, answers}
+    istqb/sample-exam/answers = {metadata, answers}
   }
 }
 
@@ -24,11 +24,6 @@
 \istqbtableofcontents
 
 % Document Text
-\istqblandscapebegin
-\istqbunnumberedsection{Answer Key}
-\markdownInput[snippet=answer-key]{sample-exam-answers/questions.yml}
-\istqbunnumberedsection{Answers}
 \markdownInput[snippet=answers]{sample-exam-answers/questions.yml}
-\istqblandscapeend
 
 \end{document}

--- a/sample-exam-answers.tex
+++ b/sample-exam-answers.tex
@@ -2,7 +2,7 @@
 \usepackage{markdown}
 \markdownSetup{
   import = {
-    istqb/sample-exam/answers = {metadata, answers}
+    istqb/sample-exam/answers = {metadata, answers@v2 as answers}
   }
 }
 

--- a/sample-exam-questions.tex
+++ b/sample-exam-questions.tex
@@ -2,7 +2,7 @@
 \usepackage{markdown}
 \markdownSetup{
   import = {
-    istqb/sample-exam/questions = {metadata, questions}
+    istqb/sample-exam/questions = {metadata, questions, additional-questions}
   }
 }
 
@@ -26,5 +26,8 @@
 % Document Text
 \istqbunnumberedsection{Questions}
 \markdownInput[snippet=questions]{sample-exam-questions/questions.yml}
+
+\istqbunnumberedsection{Additional Questions}
+\markdownInput[snippet=additional-questions]{sample-exam-questions/questions.yml}
 
 \end{document}

--- a/sample-exam-questions.tex
+++ b/sample-exam-questions.tex
@@ -27,7 +27,11 @@
 \istqbunnumberedsection{Questions}
 \markdownInput[snippet=questions]{sample-exam-questions/questions.yml}
 
+\begin{istqbappendices}
+
 \istqbunnumberedsection{Additional Questions}
 \markdownInput[snippet=additional-questions]{sample-exam-questions/questions.yml}
+
+\end{istqbappendices}
 
 \end{document}

--- a/sample-exam-questions.tex
+++ b/sample-exam-questions.tex
@@ -2,7 +2,7 @@
 \usepackage{markdown}
 \markdownSetup{
   import = {
-    istqb/sample-exam/questions = {metadata, questions}
+    istqb/sample-exam/questions = {metadata, questions@v2 as questions}
   }
 }
 

--- a/sample-exam-questions.tex
+++ b/sample-exam-questions.tex
@@ -2,7 +2,7 @@
 \usepackage{markdown}
 \markdownSetup{
   import = {
-    istqb/sample-exam/questions = {metadata, questions, additional-questions}
+    istqb/sample-exam/questions = {metadata, questions}
   }
 }
 
@@ -24,14 +24,6 @@
 \istqbtableofcontents
 
 % Document Text
-\istqbunnumberedsection{Questions}
 \markdownInput[snippet=questions]{sample-exam-questions/questions.yml}
-
-\begin{istqbappendices}
-
-\istqbunnumberedsection{Additional Questions}
-\markdownInput[snippet=additional-questions]{sample-exam-questions/questions.yml}
-
-\end{istqbappendices}
 
 \end{document}

--- a/sample-exam/question-04.md
+++ b/sample-exam/question-04.md
@@ -3,6 +3,7 @@ lo: 1.4.2
 k-level: K2
 points: 1
 correct: a
+additional: true
 
 ## question
 Given the following test activities and tasks:

--- a/sample-exam/questions-02-and-03.md
+++ b/sample-exam/questions-02-and-03.md
@@ -3,6 +3,7 @@ lo: 1.4.2
 k-level: K2
 points: 1
 correct: b
+additional: true
 
 ## question
 Which of the following factors (i-v) have SIGNIFICANT influence on the test process?
@@ -37,6 +38,7 @@ lo: 1.4.5
 k-level: K2
 points: 1
 correct: 1., e)
+additional: false
 
 ## question
 Which TWO of the following tasks belong MAINLY to a testing role?


### PR DESCRIPTION
This PR updates example Sample Exam documents and demonstrates PR https://github.com/istqborg/istqb_product_base/pull/164.

Here is how the example documents look after this PR:
- [`ISTQB-CT-TEMP-Sample Exam Questions-v0.1-EN.docx`](https://github.com/user-attachments/files/18353764/ISTQB-CT-TEMP-Sample.Exam.Questions-v0.1-EN.docx)
- [`ISTQB-CT-TEMP-Sample Exam Questions-v0.1-EN.pdf`](https://github.com/user-attachments/files/18353766/ISTQB-CT-TEMP-Sample.Exam.Questions-v0.1-EN.pdf)
- [`ISTQB-CT-TEMP-Sample Exam Answers-v0.1-EN.pdf`](https://github.com/user-attachments/files/18353768/ISTQB-CT-TEMP-Sample.Exam.Answers-v0.1-EN.pdf)

Before merging this PR, we should:
- Merge PR https://github.com/istqborg/istqb_product_base/pull/164.
- Revert commit ef64f41c8dd9cc84bf9a7bdf988df51ecb7a157c from this PR.

After merging this PR, @danopolan committed to updating the Sample Exam Questions and Answers documents in other repositories to match the changes introduced in this PR. However, since the snippets are versioned (adding `@v2` after the snippet name enables the new functionality), older documents will continue to work as before. Therefore, updates to documents without additional questions can be deferred or skipped entirely.